### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,0 +1,24 @@
+name: iOS Build and Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.1'
+      - name: Build and run tests
+        run: |
+          xcodebuild \
+            -scheme HNSwift \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            build test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the iOS project and runs unit tests on `macos-latest`

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbcc540f4832f95e3f16be8b334f3